### PR TITLE
fix: null selector in shouldUpdate

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,23 +3,21 @@
 Guided tour/walkthrough component for react projects.
 
 [npm](https://www.npmjs.com/package/walktour) |
-[GitHub](https://github.com/alfrdmalr/walktour)
+[GitHub](https://github.com/RocketSoftware/walktour)
 
-[Try the demo!](https://alfrdmalr.github.io/walktour/demo)
-
-[Options via Storybook](https://alfrdmalr.github.io/walktour)
+[Options via Storybook](https://rocketcarbon.netlify.com/?path=/story/tour--default)
 
 ### Installation
-* `npm i walktour`
+* `npm i @rocketsoftware/walktour`
 
 or, if you prefer yarn: 
-* `yarn add walktour`
+* `yarn add @rocketsoftware/walktour`
 
 ### How To Use
 
 Import the Walktour component:
 
-`import { Walktour } from 'walktour'`
+`import { Walktour } from '@rocketsoftware/walktour'`
 
 And then include it somewhere in your render function:
 
@@ -201,7 +199,7 @@ class App extends Component<> {
 ### Development / Demo
 Clone the repo with:
 
-`git clone https://github.com/alfrdmalr/walktour.git`
+`git clone https://github.com/RocketSoftware/walktour.git`
 
 Navigate to the new directory and install the necessary development dependencies:
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "walktour",
-  "version": "4.3.1",
+  "name": "@rocketsoftware/walktour",
+  "version": "4.3.2",
   "description": "Guided tour/walkthrough component for react",
   "main": "dist/index.js",
   "module": "dist/index.es.js",
@@ -20,7 +20,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/alfrdmalr/walktour"
+    "url": "https://github.com/RocketSoftware/walktour"
   },
   "license": "MIT",
   "peerDependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rocketsoftware/walktour",
-  "version": "4.3.2",
+  "version": "0.0.0",
   "description": "Guided tour/walkthrough component for react",
   "main": "dist/index.js",
   "module": "dist/index.es.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rocketsoftware/walktour",
-  "version": "0.0.0",
+  "version": "4.3.2",
   "description": "Guided tour/walkthrough component for react",
   "main": "dist/index.js",
   "module": "dist/index.es.js",

--- a/src/utils/tour.ts
+++ b/src/utils/tour.ts
@@ -176,12 +176,12 @@ export function targetChanged(args: TargetChangedArgs): boolean {
 export interface ShouldUpdateArgs extends TargetChangedArgs, ShouldScrollArgs { }
 
 export function shouldUpdate(args: ShouldUpdateArgs): boolean {
-  const { root, tooltip } = args;
+  const { root, tooltip, target } = args;
   if (!root || !tooltip) {
     return false; // bail if these aren't present; need them for calculations
   }
 
-  return targetChanged({ ...args }) || shouldScroll({ ...args }); // future todo: if no target, check if tooltip is correctly positioned (null selector -> tooltip out of place)
+  return targetChanged({ ...args }) || shouldScroll({ ...args }) || target === null;
 }
 
 export const takeActionIfValid = async (action: () => void, actionValidator?: () => Promise<boolean>) => {


### PR DESCRIPTION
Closes #96 
Fixes `shouldUpdate` to evaluate to true when the `target` is `null`

if target == null, targetChanged evaluates to false at:
https://github.com/alfrdmalr/walktour/blob/773ad31a5cb9a2b40e701cf29a3a5a3b0a9aeb3e/src/utils/tour.ts#L156-L160
shouldScroll evaluates to false as well prevent updateTour from being called entirely:
https://github.com/alfrdmalr/walktour/blob/773ad31a5cb9a2b40e701cf29a3a5a3b0a9aeb3e/src/utils/tour.ts#L133-L136