### PR TITLE
Feature/custom mask

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,6 +87,7 @@ Step-level options will take precedence over global options, so take care when u
 | _renderTolerance_ | number | Distance, in pixels, for the target element to have moved/resized before triggering an update. Applies to the `movingTarget` option as well as the default window resize recalculation. Default is 2. |
 | _updateInterval_ | number | Duration, in milliseconds, between polling for changes to a target's positioning. For use with `movingTarget` option. Default is 500. |
 | _disableMask_ | boolean | Disable the overlay and cutout. Default is false. |
+| _renderMask | (options: MaskOptions) => JSX.Element | Optional replacement mask renderer. |
 | _disableSmoothScroll_ | boolean | Disable supporting browsers scrolling smoothly to offscreen elements. Default is false. |
 | _allowForeignTarget_ | boolean | Allows the tour to target elements outside of it's root container. The tour and its elements will still be bound to that container, so it's best used for elements that are immediately bordering the container, like a menu shell. Foreign targets cannot be highlighted. |
 | _nextOnTargetClick_ | boolean | Determines whether interacting with the target should advance the tour. Currently only supports clickable targets (buttons). |

--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ Step-level options will take precedence over global options, so take care when u
 | _renderTolerance_ | number | Distance, in pixels, for the target element to have moved/resized before triggering an update. Applies to the `movingTarget` option as well as the default window resize recalculation. Default is 2. |
 | _updateInterval_ | number | Duration, in milliseconds, between polling for changes to a target's positioning. For use with `movingTarget` option. Default is 500. |
 | _disableMask_ | boolean | Disable the overlay and cutout. Default is false. |
-| _renderMask | (options: MaskOptions) => JSX.Element | Optional replacement mask renderer. |
+| _renderMask_ | (options: MaskOptions) => JSX.Element | Optional replacement mask renderer. |
 | _disableSmoothScroll_ | boolean | Disable supporting browsers scrolling smoothly to offscreen elements. Default is false. |
 | _allowForeignTarget_ | boolean | Allows the tour to target elements outside of it's root container. The tour and its elements will still be bound to that container, so it's best used for elements that are immediately bordering the container, like a menu shell. Foreign targets cannot be highlighted. |
 | _nextOnTargetClick_ | boolean | Determines whether interacting with the target should advance the tour. Currently only supports clickable targets (buttons). |

--- a/src/components/Mask.tsx
+++ b/src/components/Mask.tsx
@@ -1,37 +1,39 @@
 import * as React from 'react';
-import { Coords, Dims, getElementDims } from '../utils/dom';
-import { getTargetPosition } from '../utils/positioning';
+import { Coords, Dims } from '../utils/dom';
 import { getViewportScrollDims } from '../utils/viewport';
 
-interface MaskProps {
-  target: HTMLElement;
+export interface MaskOptions {
+  targetInfo?: {
+    coords: Coords,
+    dims: Dims
+  };
   padding: number;
   close: () => void;
   tourRoot: Element;
   disableMaskInteraction?: boolean;
   disableCloseOnClick?: boolean;
   maskId: string;
-  
 }
 
-export function Mask(props: MaskProps): JSX.Element {
-  const { target, disableMaskInteraction, padding, tourRoot, close, disableCloseOnClick, maskId } = props;
+export function Mask(props: MaskOptions): JSX.Element {
+  const { targetInfo, disableMaskInteraction, padding, tourRoot, close, disableCloseOnClick, maskId } = props;
   const {width: containerWidth, height: containerHeight} = getViewportScrollDims(tourRoot);
   const pathId = `clip-path-${maskId}`;
 
-
-  const getCutoutPoints = (target: HTMLElement): string => {
+  const getCutoutPoints = (target?: {coords: Coords, dims: Dims}): string => {
     if (!target) {
       return '';
     }
 
-    const targetDims: Dims = getElementDims(target);
-    const coords: Coords = getTargetPosition(tourRoot, target);
+    const {
+      dims,
+      coords
+    } = target;
 
     const cutoutTop: number = coords.y - padding;
     const cutoutLeft: number = coords.x - padding;
-    const cutoutRight: number = coords.x + targetDims.width + padding;
-    const cutoutBottom: number = coords.y + targetDims.height + padding;
+    const cutoutRight: number = coords.x + dims.width + padding;
+    const cutoutBottom: number = coords.y + dims.height + padding;
 
     return `0 0, 
             0 ${containerHeight}, 
@@ -53,10 +55,10 @@ export function Mask(props: MaskProps): JSX.Element {
 
   return (
     <svg style={svgStyle}>
-      {target &&
+      {targetInfo &&
         <defs>
           <clipPath id={pathId}>
-            <polygon points={getCutoutPoints(target)}
+            <polygon points={getCutoutPoints(targetInfo)}
             />
           </clipPath>
         </defs>
@@ -71,7 +73,7 @@ export function Mask(props: MaskProps): JSX.Element {
         fill='black'
         fillOpacity={0.3}
         pointerEvents='auto'
-        clipPath={target ? `url(#${pathId})` : undefined}
+        clipPath={targetInfo ? `url(#${pathId})` : undefined}
       />
     </svg>
   );

--- a/src/components/Mask.tsx
+++ b/src/components/Mask.tsx
@@ -10,13 +10,12 @@ interface MaskProps {
   tourRoot: Element;
   disableMaskInteraction?: boolean;
   disableCloseOnClick?: boolean;
-  disableMask?: boolean;
   maskId: string;
   
 }
 
 export function Mask(props: MaskProps): JSX.Element {
-  const { target, disableMaskInteraction, padding, tourRoot, close, disableCloseOnClick, maskId, disableMask } = props;
+  const { target, disableMaskInteraction, padding, tourRoot, close, disableCloseOnClick, maskId } = props;
   const {width: containerWidth, height: containerHeight} = getViewportScrollDims(tourRoot);
   const pathId = `clip-path-${maskId}`;
 
@@ -50,7 +49,6 @@ export function Mask(props: MaskProps): JSX.Element {
     height: containerHeight,
     width: containerWidth,
     pointerEvents: disableMaskInteraction ? 'auto' : 'none',
-    visibility: disableMask ? 'hidden' : 'visible'
   }
 
   return (

--- a/src/components/Mask.tsx
+++ b/src/components/Mask.tsx
@@ -1,12 +1,9 @@
 import * as React from 'react';
-import { Coords, Dims } from '../utils/dom';
+import { Coords, Dims, ElementInfo } from '../utils/dom';
 import { getViewportScrollDims } from '../utils/viewport';
 
 export interface MaskOptions {
-  targetInfo?: {
-    coords: Coords,
-    dims: Dims
-  };
+  targetInfo?: ElementInfo;
   padding: number;
   close: () => void;
   tourRoot: Element;

--- a/src/components/Walktour.tsx
+++ b/src/components/Walktour.tsx
@@ -379,16 +379,17 @@ export const Walktour = (props: WalktourProps) => {
     >
       {tourRoot &&
         <>
-          <Mask
-            maskId={getIdString(baseMaskString, identifier)}
-            target={target}
-            disableMaskInteraction={disableMaskInteraction}
-            disableCloseOnClick={disableCloseOnClick}
-            disableMask={disableMask}
-            padding={maskPadding}
-            tourRoot={tourRoot}
-            close={tourLogic.close}
-          />
+          {!disableMask &&
+            <Mask
+              maskId={getIdString(baseMaskString, identifier)}
+              target={target}
+              disableMaskInteraction={disableMaskInteraction}
+              disableCloseOnClick={disableCloseOnClick}
+              padding={maskPadding}
+              tourRoot={tourRoot}
+              close={tourLogic.close}
+            />
+        }
 
           <div
             ref={ref => tooltip.current = ref}

--- a/src/components/Walktour.tsx
+++ b/src/components/Walktour.tsx
@@ -1,9 +1,9 @@
 import * as React from 'react';
 import * as ReactDOM from 'react-dom';
-import { Mask } from './Mask';
+import { Mask, MaskOptions } from './Mask';
 import { Tooltip } from './Tooltip';
 import { CardinalOrientation, OrientationCoords, getTargetPosition, getTooltipPosition } from '../utils/positioning';
-import { Coords, getNearestScrollAncestor, getValidPortalRoot, Dims, getElementDims } from '../utils/dom';
+import { Coords, getNearestScrollAncestor, getValidPortalRoot, Dims, getElementDims, getTargetInfo } from '../utils/dom';
 import { scrollToDestination } from '../utils/scroll';
 import { centerViewportAroundElements } from '../utils/offset';
 import { debounce, getIdString, shouldUpdate, setFocusTrap, setTargetWatcher, setTourUpdateListener, shouldScroll, setNextOnTargetClick } from '../utils/tour';
@@ -45,6 +45,7 @@ export interface WalktourOptions {
   updateInterval?: number;
   renderTolerance?: number;
   disableMask?: boolean;
+  renderMask?: (maskOptions: MaskOptions) => JSX.Element;
   disableSmoothScroll?: boolean;
   allowForeignTarget?: boolean;
   nextOnTargetClick?: boolean;
@@ -147,6 +148,7 @@ export const Walktour = (props: WalktourProps) => {
     allowForeignTarget,
     nextOnTargetClick,
     validateNextOnTargetClick,
+    renderMask
   } = options;
 
   React.useEffect(() => {
@@ -370,6 +372,8 @@ export const Walktour = (props: WalktourProps) => {
     pointerEvents: 'auto'
   }
 
+  const MaskTag = renderMask ? renderMask : Mask;
+
   // render mask, tooltip, and their shared "portal" container
   const render = () => (
     <div
@@ -380,16 +384,16 @@ export const Walktour = (props: WalktourProps) => {
       {tourRoot &&
         <>
           {!disableMask &&
-            <Mask
+            <MaskTag
               maskId={getIdString(baseMaskString, identifier)}
-              target={target}
+              targetInfo={getTargetInfo(tourRoot, target)}
               disableMaskInteraction={disableMaskInteraction}
               disableCloseOnClick={disableCloseOnClick}
               padding={maskPadding}
               tourRoot={tourRoot}
               close={tourLogic.close}
             />
-        }
+          }
 
           <div
             ref={ref => tooltip.current = ref}

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,11 +1,14 @@
 import { Walktour } from './components/Walktour';
+import { Mask, MaskOptions } from './components/Mask';
 import type { Step, WalktourProps, WalktourOptions, WalktourLogic } from './components/Walktour';
 import { CardinalOrientation } from './utils/positioning';
 
-export { Walktour };
+export { Walktour }
+export { Mask };
+
 export { Step };
+export { MaskOptions };
 export { WalktourProps };
 export { WalktourLogic };
 export { WalktourOptions };
 export { CardinalOrientation };
-

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,6 +2,7 @@ import { Walktour } from './components/Walktour';
 import { Mask, MaskOptions } from './components/Mask';
 import type { Step, WalktourProps, WalktourOptions, WalktourLogic } from './components/Walktour';
 import { CardinalOrientation } from './utils/positioning';
+import { Coords, Dims, ElementInfo } from './utils/dom';
 
 export { Walktour }
 export { Mask };
@@ -12,3 +13,4 @@ export { WalktourProps };
 export { WalktourLogic };
 export { WalktourOptions };
 export { CardinalOrientation };
+export { Coords, Dims, ElementInfo };

--- a/src/utils/dom.ts
+++ b/src/utils/dom.ts
@@ -11,7 +11,7 @@ export interface Dims {
   height: number;
 }
 
-export interface TargetInfo {
+export interface ElementInfo {
   dims: Dims;
   coords: Coords;
 }
@@ -223,7 +223,7 @@ export function getEdgeFocusables(defaultElement: HTMLElement, container?: HTMLE
   }
 }
 
-export function getTargetInfo(root: Element, target?: HTMLElement) {
+export function getTargetInfo(root: Element, target?: HTMLElement): ElementInfo | undefined {
   if (!root || !target) {
     return;
   }

--- a/src/utils/dom.ts
+++ b/src/utils/dom.ts
@@ -1,4 +1,5 @@
 import { focusableSelector } from "./constants";
+import { getTargetPosition } from "./positioning";
 
 export interface Coords {
   x: number;
@@ -8,6 +9,11 @@ export interface Coords {
 export interface Dims {
   width: number;
   height: number;
+}
+
+export interface TargetInfo {
+  dims: Dims;
+  coords: Coords;
 }
 
 export function isValidCoords(coords: Coords): boolean {
@@ -214,6 +220,19 @@ export function getEdgeFocusables(defaultElement: HTMLElement, container?: HTMLE
   return {
     start: defaultElement,
     end: defaultElement
+  }
+}
+
+export function getTargetInfo(root: Element, target?: HTMLElement) {
+  if (!root || !target) {
+    return;
+  }
+  const dims: Dims = getElementDims(target);
+  const coords: Coords = getTargetPosition(root, target);
+
+  return {
+    coords,
+    dims
   }
 }
 


### PR DESCRIPTION
Did some internal refactoring in the default mask component so it no longer needs to know about:
- disabling itself
- the reference to the target element

Instead, the main component conditionally renders the mask as needed, and passes a new `ElementInfo` type to represent the dimensions and coordinates of the target. 

Additionally, expose a new option: `renderMask`, which takes in the same set of props as the default mask and produces a JSX Element to be rendered in the tour root.